### PR TITLE
Updated installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Subtitlr is an open source OS X app used to find and download subtitles easily. 
 
 ## Installation
 
-Checkout the project and use **Subtitlr 2.0.xcworkspace** to open the project (this is necessary because Subtitlr uses CocoaPods for XMLRPC support).
+
+### Prerequisites
+1. XCode (can be downloaded from the app store)
+2. [CocoaPods](https://cocoapods.org)
+
+### Installation Instructions
+Clone the repository into a folder of your choice, and run `pod install` inside that folder. This will download the necessary dependencies and create a **Subtitlr.xcworkspace** file.
+
+Open the **Subtitlr.xcworkspace** file in XCode, go to "Product->Build" in the top bar, once this has built right-click on the "Products" folder in the left hand sidebar, and click "Open in Finder". **Subtitlr.app** will be in there, you can then drag this into your Applications folder.
 
 Alternatively, you can download Subtitlr.app in a ZIP file [here] (https://www.dropbox.com/s/et60e6lcvi3h2qc/Subtitlr.zip?dl=0). 


### PR DESCRIPTION
Hi @spilja, I've updated the readme to include some more in-depth installation instructions, as the `xcworkspace` file is not included in the repository until after `pod install` has been ran. 

I also recommend including a `.app` binary in each release (these can be dragged on when creating a release).
